### PR TITLE
add mutex to stop race in pkg `math/rand`

### DIFF
--- a/cuid.go
+++ b/cuid.go
@@ -21,6 +21,7 @@ var (
 	discreteValues            = int32(math.Pow(BASE, BLOCK_SIZE))
 	padding                   = strings.Repeat("0", BLOCK_SIZE)
 	fingerprint               = ""
+	mu             sync.Mutex
 )
 
 func init() {
@@ -47,14 +48,20 @@ func SetRandomSource(src rand.Source) {
 }
 
 func SetRandom(rnd *rand.Rand) {
+	mu.Lock()
+	defer mu.Unlock()
 	random = rnd
 }
 
 func SetCounter(cnt Counter) {
+	mu.Lock()
+	defer mu.Unlock()
 	counter = cnt
 }
 
 func New() string {
+	mu.Lock()
+	defer mu.Unlock()
 	timestampBlock := strconv.FormatInt(time.Now().Unix()*1000, BASE)
 	counterBlock := pad(strconv.FormatInt(int64(counter.Next()), BASE), BLOCK_SIZE)
 	randomBlock1 := pad(strconv.FormatInt(int64(random.Int31n(discreteValues)), BASE), BLOCK_SIZE)


### PR DESCRIPTION
This PR adds a mutex to be shared by functions in the cuid package because `math/rand`'s Rand struct is not meant to be shared between threads. Doing so will create a race in `math/rand/rng.go`'s rngSource struct. 

To demonstrate this, I wrote a test program that I've put in [this gist here](https://gist.github.com/hopkinsth/50bc543d21c774633a1d). I built it with `go build -race` to get race detection baked in, and ran it. If you do the same, the program should spit out something similar to [race.log in the gist](https://gist.github.com/hopkinsth/50bc543d21c774633a1d#file-race-log). I'm running on darwin64 in this case, specifically `go1.4.2 darwin/amd64`

I've added a mutex to lock both cuid generation (the `New` function) _and_ the functions that replace the rand struct (`SetRandom`) and the counter struct (`SetCounter`). Because they're all tied to interdependent data accesses, it made sense to guard them all with the same lock. 

But I'm not sure what the implications of this are for the cuid algorithm. Maybe it doesn't matter. Would like to get some feedback if you feel this isn't appropriate to merge outright. Thanks!
