### PR TITLE
Adds option to generate a CUID using crypto/rand

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,26 @@ ew0k9fwpl
 ```Go
 package main
 
-import fmt
+import (
+
+"crypto/rand"
+"fmt"
+)
 import "gopkg.in/lucsky/cuid.v1"
 
 func main() {
+    // Generate pseudo-random CUID
     fmt.Println(cuid.New())
+    // Generate slug
     fmt.Println(cuid.Slug())
+
+    // Generate cryptographically random CUID
+    c, err := cuid.NewCrypto(rand.Reader)
+    if err != nil {
+        fmt.Printf("%v", err)
+        return
+    }
+    fmt.Println(c)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ ew0k9fwpl
 package main
 
 import (
+    "crypto/rand"
+    "fmt"
 
-"crypto/rand"
-"fmt"
+    "gopkg.in/lucsky/cuid.v1"
 )
-import "gopkg.in/lucsky/cuid.v1"
 
 func main() {
     // Generate pseudo-random CUID
@@ -42,7 +42,7 @@ func main() {
     // Generate slug
     fmt.Println(cuid.Slug())
 
-    // Generate cryptographically random CUID
+    // Generate cryptographic-random CUID
     c, err := cuid.NewCrypto(rand.Reader)
     if err != nil {
         fmt.Printf("%v", err)

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -1,0 +1,47 @@
+package cuid
+
+import (
+	"crypto/rand"
+	"reflect"
+	"testing"
+)
+
+func Test_CUIDCryptoType(t *testing.T) {
+	c, e := NewCrypto(rand.Reader)
+	if e != nil {
+		t.Errorf("Failed to generate crypto cuid: %v", e)
+	}
+	if reflect.TypeOf(c).Name() != "string" {
+		t.Error("Incorrect CUID type")
+	}
+}
+
+func Test_CUIDCryptoFormat(t *testing.T) {
+	c, e := NewCrypto(rand.Reader)
+	if e != nil {
+		t.Errorf("Failed to generate crypto cuid: %v", e)
+	}
+	if err := IsCuid(c); err != nil {
+		t.Error("Incorrect format")
+	}
+}
+
+func Test_CUIDCryptoCollisions(t *testing.T) {
+	ids := map[string]bool{}
+	for i := 0; i < 600000; i++ {
+		id, e := NewCrypto(rand.Reader)
+		if e != nil {
+			t.Errorf("Failed to generate crypto cuid, at iteration %d: %v", i, e)
+		}
+		if ids[id] == true {
+			t.Errorf("Collision detected, at iteration %d", i)
+		}
+		ids[id] = true
+	}
+}
+
+func Benchmark_CryptoCUIDGeneration(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewCrypto(rand.Reader)
+	}
+}


### PR DESCRIPTION
For security purposes, we need the ability to generate CUIDs using `crypto/rand` rather than `math/rand`. This PR enables that by adding a `NewCrypto(io.Reader) (string, error)` method.

Example usage:

```
package main

import (
    "crypto/rand"
    "fmt"
    "gopkg.in/lucsky/cuid.v1"
)

func main() {
    // Generate cryptographic-random CUID
    c, err := cuid.NewCrypto(rand.Reader)
    if err != nil {
        fmt.Printf("%v", err)
        return
    }
    fmt.Println(c)
}
```