### PR TITLE
Fixed conversion of hostname part of fingerprint to base 36

### DIFF
--- a/cuid.go
+++ b/cuid.go
@@ -46,7 +46,7 @@ func init() {
 	}
 
 	hostID := pad(strconv.FormatInt(int64(os.Getpid()), base), 2)
-	host := pad(strconv.FormatInt(int64(acc), 10), 2)
+	host := pad(strconv.FormatInt(int64(acc), base), 2)
 	fingerprint = hostID + host
 }
 


### PR DESCRIPTION
For some reason hostname part of fingerprint is not converted to base 36 as other CUID implementations do but left in base 10.